### PR TITLE
non-observed traces still set span thread state

### DIFF
--- a/barista-tracing/src/main/java/com/markelliot/barista/tracing/EmptyTrace.java
+++ b/barista-tracing/src/main/java/com/markelliot/barista/tracing/EmptyTrace.java
@@ -30,26 +30,31 @@ public final class EmptyTrace implements Trace {
 
     @Override
     public Span rootSpan(String opName) {
-        return singletonSpan;
+        return getSpan();
     }
 
     @Override
     public Span rootSpan(Supplier<String> opName) {
-        return singletonSpan;
+        return getSpan();
     }
 
     @Override
     public Span withParent(String parentId, String opName) {
-        return singletonSpan;
+        return getSpan();
     }
 
     @Override
     public Span withParent(String parentId, Supplier<String> opName) {
-        return singletonSpan;
+        return getSpan();
     }
 
     @Override
     public String traceId() {
         return traceId;
+    }
+
+    private Span getSpan() {
+        Spans.setThreadSpan(singletonSpan);
+        return singletonSpan;
     }
 }

--- a/barista-tracing/src/main/java/com/markelliot/barista/tracing/EmptyTrace.java
+++ b/barista-tracing/src/main/java/com/markelliot/barista/tracing/EmptyTrace.java
@@ -53,6 +53,12 @@ public final class EmptyTrace implements Trace {
         return traceId;
     }
 
+    /**
+     * Attach thread state and return the singleton span.
+     *
+     * <p>Note that we perform this lazily to maintain the contract that creating a trace does not
+     * immediately attach trace state to the current thread.
+     */
     private Span getSpan() {
         Spans.setThreadSpan(singletonSpan);
         return singletonSpan;


### PR DESCRIPTION
We would not update the thread state when a trace was unobserved, prevent other parts of the system from seeing the traceId