### PR TITLE
Differentiate EmptySpan from SingletonSpan

### DIFF
--- a/barista-tracing/src/main/java/com/markelliot/barista/tracing/EmptyTrace.java
+++ b/barista-tracing/src/main/java/com/markelliot/barista/tracing/EmptyTrace.java
@@ -21,11 +21,11 @@ import java.util.function.Supplier;
 public final class EmptyTrace implements Trace {
 
     private final String traceId;
-    private final EmptySpan singletonSpan;
+    private final SingletonSpan singletonSpan;
 
     EmptyTrace(String traceId) {
         this.traceId = traceId;
-        this.singletonSpan = new EmptySpan(traceId);
+        this.singletonSpan = new SingletonSpan(traceId);
     }
 
     @Override

--- a/barista-tracing/src/main/java/com/markelliot/barista/tracing/SingletonSpan.java
+++ b/barista-tracing/src/main/java/com/markelliot/barista/tracing/SingletonSpan.java
@@ -24,14 +24,17 @@ package com.markelliot.barista.tracing;
 
 /**
  * A no-overhead, no-op, no-allocation {@link Span} implementation used to make unobserved traces
- * effectively free. Unlike {@link SingletonSpan} this span contains no inherent traceId.
+ * effectively free. This span keeps track of the original traceId and makes the traceId available
+ * to callers.
  *
  * <p>See {@link DefaultSpan} for a real {@link Span} implementation.
  */
-final class EmptySpan implements Span {
-    public static final Span INSTANCE = new EmptySpan();
+final class SingletonSpan implements Span {
+    private final String traceId;
 
-    private EmptySpan() {}
+    SingletonSpan(String traceId) {
+        this.traceId = traceId;
+    }
 
     @Override
     public Span sibling(String _opName) {
@@ -48,7 +51,7 @@ final class EmptySpan implements Span {
 
     @Override
     public String traceId() {
-        throw new UnsupportedOperationException("cannot get traceId of an empty span");
+        return traceId;
     }
 
     @Override

--- a/barista-tracing/src/main/java/com/markelliot/barista/tracing/Spans.java
+++ b/barista-tracing/src/main/java/com/markelliot/barista/tracing/Spans.java
@@ -51,7 +51,7 @@ public final class Spans {
         // note that we make assumptions elsewhere predicated on the idea that it is not and will
         // not be possible to retrieve the current span directly, so it is necessary that we always
         // create a child span when using implicit spans.
-        return getThreadSpan().orElse(new EmptySpan("none")).child(opName);
+        return getThreadSpan().orElse(EmptySpan.INSTANCE).child(opName);
     }
 
     public static Optional<String> maybeGetTraceId() {


### PR DESCRIPTION
Before this PR, we had to use the special traceId 'none' to mean a Span that was created when no trace state was attached to the current thread.

After this PR, we differentiate unobserved traces (EmptyTrace) from untraced calls.
